### PR TITLE
fix: route to /accessibility-statement not working #3 (#6)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from "vite";
+import { resolve } from "path";
 
 export default defineConfig(({}) => {
   return {
-    base: "/",
+    // base: "/",
+    build: {
+      outDir: "build",
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, "index.html"),
+          other: resolve(__dirname, "accessibility-statement/index.html"),
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
* updates vite build config

* Adds prettierrc and eslintrc

* Adds accessibility-statement to rollup routes in vite.config.js

* removed eslintrc and prettierrc